### PR TITLE
Studying Arrow Convertions

### DIFF
--- a/studies/arrow_c_interface.cpp
+++ b/studies/arrow_c_interface.cpp
@@ -1,0 +1,99 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+extern "C" {
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+static void release_int32_type(struct ArrowSchema* schema) {
+   // Mark released
+   schema->release = NULL;
+}
+
+void export_int32_type(struct ArrowSchema* schema) {
+   *schema = (struct ArrowSchema) {
+      // Type description
+      .format = "l",
+      .name = "",
+      .metadata = NULL,
+      .flags = 0,
+      .n_children = 0,
+      .children = NULL,
+      .dictionary = NULL,
+      // Bookkeeping
+      .release = &release_int32_type
+   };
+}
+
+static void release_int32_array(struct ArrowArray* array) {
+   assert(array->n_buffers == 2);
+   // Free the buffers and the buffers array
+   free((void *) array->buffers[1]);
+   free(array->buffers);
+   // Mark released
+   array->release = NULL;
+}
+
+void export_int32_array(const int32_t* data, int64_t nitems,
+                        struct ArrowArray* array) {
+   // Initialize primitive fields
+   *array = (struct ArrowArray) {
+      // Data description
+      .length = nitems,
+      .null_count = 0,
+      .offset = 0,
+      .n_buffers = 2,
+      .n_children = 0,
+      .buffers = NULL,
+      .children = NULL,
+      .dictionary = NULL,
+      // Bookkeeping
+      .release = &release_int32_array
+   };
+   // Allocate list of buffers
+   array->buffers = (const void**) malloc(sizeof(void*) * array->n_buffers);
+   assert(array->buffers != NULL);
+   array->buffers[0] = NULL;  // no nulls, null bitmap can be omitted
+   array->buffers[1] = data;
+}
+
+ArrowArray view_contents(struct ArrowArray* arr)
+{
+   return *arr;
+}
+
+}

--- a/studies/use-arrow.py
+++ b/studies/use-arrow.py
@@ -1,0 +1,49 @@
+import pyarrow as pa
+import pandas as pd
+import numpy as np
+from ctypes import *
+
+class ArrowSchema(Structure):
+    pass
+
+release_func_ptr_schema = CFUNCTYPE(c_void_p, POINTER(ArrowSchema))
+
+ArrowSchema._fields_ = [("format", c_char_p),
+                        ("name", c_char_p),
+                        ("metadata", c_char_p),
+                        ("flags", c_longlong),
+                        ("n_children", c_longlong),
+                        ("children", POINTER(POINTER(ArrowSchema))),
+                        ("dictionary", POINTER(ArrowSchema)),
+                        ("release", release_func_ptr_schema),
+                        ("private_data", c_void_p)]
+
+
+class ArrowArray(Structure):
+    pass
+
+release_func_ptr_array = CFUNCTYPE(c_void_p, POINTER(ArrowArray))
+
+ArrowArray._fields_ =[("length", c_longlong),
+                      ("null_count", c_longlong),
+                      ("offset", c_longlong),
+                      ("n_buffers", c_longlong),
+                      ("n_children", c_longlong),
+                      ("buffers", POINTER(c_void_p)),
+                      ("children", POINTER(POINTER(ArrowArray))),
+                      ("dictionary", POINTER(ArrowArray)),
+                      ("release", release_func_ptr_array),
+                      ("private_data", c_void_p)]
+
+lib = cdll.LoadLibrary('./libfoo.so')
+arr = pa.array([1, 2, 3, 4])
+# print(np.frombuffer(arr , dtype=np.uint8))
+int32_arr = c_int * 4
+arr_ptr = int32_arr(1, 2, 3, 4)
+# print(arr_ptr)
+scheme = ArrowSchema()
+lib.export_int32_type(pointer(scheme))
+# print(scheme)
+arrow_arr = ArrowArray()
+lib.export_int32_array(arr_ptr, 10, pointer(arrow_arr))
+print(np.frombuffer(arrow_arr, dtype=np.uint8))


### PR DESCRIPTION
@jpivarski
Use: `g++ -c -fPIC arrow_c_interface.cpp -o foo.o`
`g++ -shared -Wl,-soname,libfoo.so -o libfoo.so foo.o`
to build the c++ library. `use_arrow.py` is the python file. So far I can get the bytes from the C struct but not from the Arrow Array, it doesn't consider `pyarrow.Array` as a byte object.